### PR TITLE
Use discoveryHost for TCP health check

### DIFF
--- a/packages/grpc/README.md
+++ b/packages/grpc/README.md
@@ -25,11 +25,31 @@ The loadbalance grpc module for nestcloud.
 $ npm install --save @nestcloud/grpc
 ```
 
-## Usage
+## Quick Start
+
+### Import module
+
+*Before import `GrpcModule`, you need to import [`LoadbalanceModule`][loadbalance] first.*
+
+```typescript
+import { Module } from '@nestjs/common';
+import { LoadbalanceModule } from '@nestcloud/loadbalance'
+import { GrpcModule } from '@nestcloud/grpc';
+
+@Module({
+  imports: [
+      LoadbalanceModule.forRoot({...}),
+      GrpcModule.forRoot()
+  ],
+})
+export class AppModule {}
+```
+
+### Usage
 
 ```typescript
 import { Controller, Get } from '@nestjs/common';
-import { GrpcClient, LbClient, IClientConfig, Service } from '@nestcloud/grpc';
+import { RpcClient, GrpcClient, IClientConfig, Service } from '@nestcloud/grpc';
 import { HeroService } from './interfaces/hero-service.interface';
 import { join } from 'path';
 
@@ -41,7 +61,7 @@ const grpcOptions: IClientConfig = {
 
 @Controller()
 export class HeroController {
-    @LbClient(grpcOptions)
+    @RpcClient(grpcOptions)
     private readonly client: GrpcClient;
     @Service('HeroService', grpcOptions)
     private readonly heroService: HeroService;
@@ -62,3 +82,6 @@ More please visit the example: https://github.com/nest-cloud/nestcloud-grpc-exam
 ## License
 
   NestCloud is [MIT licensed](LICENSE).
+
+
+[loadbalance]: https://github.com/nest-cloud/nestcloud/tree/master/packages/loadbalance

--- a/packages/grpc/decorators/service.decorator.ts
+++ b/packages/grpc/decorators/service.decorator.ts
@@ -1,10 +1,10 @@
 import { ClientOptions } from '../interfaces/client-options.interface';
-import { GRPC_CLIENT } from '../grpc.constants';
+import { GRPC_SERVICE } from '../grpc.constants';
 import { applyDecorators, ExtendMetadata } from '@nestcloud/common';
 
 export function Service(name: string, options?: ClientOptions): PropertyDecorator {
     return applyDecorators((target, property) => {
-        return ExtendMetadata(GRPC_CLIENT, {
+        return ExtendMetadata(GRPC_SERVICE, {
             name,
             property,
             options,

--- a/packages/grpc/grpc.module.ts
+++ b/packages/grpc/grpc.module.ts
@@ -1,5 +1,5 @@
 import { Module, DynamicModule, Global } from '@nestjs/common';
-import { GRPC, LOADBALANCE } from '@nestcloud/common';
+import { Scanner, GRPC, LOADBALANCE } from '@nestcloud/common';
 import { DiscoveryModule } from '@nestjs/core';
 import { GrpcMetadataAccessor } from './grpc-metadata.accessor';
 import { GrpcOrchestrator } from './grpc.orchestrator';
@@ -8,7 +8,7 @@ import { GrpcExplorer } from './grpc.explorer';
 @Global()
 @Module({
     imports: [DiscoveryModule],
-    providers: [GrpcMetadataAccessor, GrpcOrchestrator],
+    providers: [Scanner, GrpcMetadataAccessor, GrpcOrchestrator],
 })
 export class GrpcModule {
     static forRoot(): DynamicModule {
@@ -16,8 +16,7 @@ export class GrpcModule {
 
         const grpcProvider = {
             provide: GRPC,
-            useFactory: async (): Promise<any> => {
-            },
+            useFactory: async (): Promise<any> => {},
             inject,
         };
 

--- a/packages/service/service.consul.ts
+++ b/packages/service/service.consul.ts
@@ -1,9 +1,8 @@
 import { OnModuleDestroy, OnModuleInit, Logger } from '@nestjs/common';
 import * as md5encode from 'blueimp-md5';
-import { IConsul } from '@nestcloud/common';
+import { IConsul, IService, IServiceServer, sleep } from '@nestcloud/common';
 import { get } from 'lodash';
 
-import { IService, sleep, IServiceServer } from '@nestcloud/common';
 import { ServiceOptions } from './interfaces/service-options.interface';
 import { ServiceCheck } from './interfaces/service-check.interface';
 import { getIPAddress } from './utils/os.util';
@@ -36,10 +35,7 @@ export class ConsulService implements OnModuleInit, OnModuleDestroy, IService {
     private readonly includes: string[];
     private readonly connect: ConnectService;
 
-    constructor(
-        private readonly consul: IConsul,
-        options: ServiceOptions,
-    ) {
+    constructor(private readonly consul: IConsul, options: ServiceOptions) {
         this.discoveryHost = get(options, 'discoveryHost', getIPAddress());
         this.serviceId = get(options, 'id');
         this.serviceName = get(options, 'name');
@@ -118,7 +114,7 @@ export class ConsulService implements OnModuleInit, OnModuleDestroy, IService {
         } as ServiceCheck;
 
         if (this.tcp) {
-            check.tcp = this.tcp;
+            check.tcp = this.tcp === 'true' ? `${this.discoveryHost}:${this.servicePort}` : this.tcp;
         } else if (this.script) {
             check.script = this.script;
         } else if (this.dockerContainerId) {


### PR DESCRIPTION
Checks if TCP parameter of Service Configuration is "true", then use serviceDiscoverHost and servicePort to Health Check.

**Problem**

I have a service in a (or multiple) docker container that I don't know the IP/Host address.