### PR TITLE
use useExisting to give alias to provider

### DIFF
--- a/packages/loadbalance/loadbalance.module.ts
+++ b/packages/loadbalance/loadbalance.module.ts
@@ -44,8 +44,7 @@ export class LoadbalanceModule {
 
         const loadbalanceProvider = {
             provide: LOADBALANCE,
-            useFactory: (lb: Loadbalance) => lb,
-            inject: [Loadbalance],
+            useExisting: Loadbalance
         };
 
         const axiosProvider = {

--- a/packages/proxy/proxy.module.ts
+++ b/packages/proxy/proxy.module.ts
@@ -6,7 +6,7 @@ import { ProxyFilterRegistry } from './proxy-filter.registry';
 import { ProxyRouteRegistry } from './proxy-route.registry';
 import { ProxyMetadataAccessor } from './proxy-metadata.accessor';
 import { DiscoveryModule } from '@nestjs/core';
-import { Scanner, BOOT, CONFIG, IBoot, IConfig, ILoadbalance, LOADBALANCE, PROXY } from '@nestcloud/common';
+import { Scanner, BOOT, CONFIG, IBoot, IConfig, PROXY } from '@nestcloud/common';
 import { ProxyFilterRegister } from './proxy-filter.register';
 import { ProxyConfig } from './proxy.config';
 
@@ -34,12 +34,7 @@ export class ProxyModule {
         };
         const proxyProvider = {
             provide: PROXY,
-            useFactory: (proxy: Proxy, ...params: any[]) => {
-                const lb: ILoadbalance = params[inject.indexOf(LOADBALANCE)];
-                proxy.useLb(lb);
-                return proxy;
-            },
-            inject: [Proxy, ...inject],
+            useExisting: Proxy
         };
         return {
             module: ProxyModule,

--- a/packages/proxy/proxy.ts
+++ b/packages/proxy/proxy.ts
@@ -1,12 +1,13 @@
 import {
     ForbiddenException,
+    Inject,
     Injectable,
     InternalServerErrorException,
     NotFoundException,
     OnModuleInit,
 } from '@nestjs/common';
 import * as HttpProxy from 'http-proxy';
-import { IProxy, ILoadbalance } from '@nestcloud/common';
+import { IProxy, ILoadbalance, LOADBALANCE } from '@nestcloud/common';
 import { get } from 'lodash';
 
 import { Route } from './interfaces/route.interface';
@@ -24,12 +25,12 @@ import { ProxyConfig } from './proxy.config';
 @Injectable()
 export class Proxy implements IProxy, OnModuleInit {
     private proxy: HttpProxy;
-    private lb: ILoadbalance;
 
     constructor(
         private readonly config: ProxyConfig,
         private readonly filterRegistry: ProxyFilterRegistry,
         private readonly routeRegistry: ProxyRouteRegistry,
+        @Inject(LOADBALANCE) private readonly lb: ILoadbalance
     ) {
     }
 
@@ -57,10 +58,6 @@ export class Proxy implements IProxy, OnModuleInit {
             this.initRoutes();
             this.initProxy();
         });
-    }
-
-    public useLb(lb: ILoadbalance) {
-        this.lb = lb;
     }
 
     private initRoutes() {

--- a/packages/schedule/schedule.module.ts
+++ b/packages/schedule/schedule.module.ts
@@ -16,14 +16,13 @@ export class ScheduleModule {
     static forRoot(): DynamicModule {
         const scheduleProvider = {
             provide: SCHEDULE,
-            useFactory: (schedule: Schedule) => schedule,
-            inject: [Schedule],
+            useExisting: Schedule,
         };
         return {
             global: true,
             module: ScheduleModule,
             providers: [ScheduleExplorer, SchedulerRegistry, ScheduleWrapper, Schedule, scheduleProvider],
-            exports: [Schedule, scheduleProvider],
+            exports: [scheduleProvider],
         };
     }
 }


### PR DESCRIPTION
### Problem
Providers(Loadbalance, Proxy, Schedule) are initialized twice, onModuleInit() in each provider is executed twice when define provider by useFactory.

### Fix
Define provider by useExisting instead.