### PR TITLE
Use forRootAsync in module initialization for code samples

### DIFF
--- a/samples/boot/01-get-config/app.module.ts
+++ b/samples/boot/01-get-config/app.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 import { BootModule } from '@nestcloud/boot';
 import { ConfigService } from "./config.service";
+import { resolve } from 'path'
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        })
     ],
     providers: [ConfigService],
 })

--- a/samples/boot/02-get-env-config/app.module.ts
+++ b/samples/boot/02-get-env-config/app.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 import { BootModule } from '@nestcloud/boot';
 import { ConfigService } from "./config.service";
+import { resolve } from 'path'
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        })
     ],
     providers: [ConfigService],
 })

--- a/samples/boot/03-use-bootvalue-decorator/app.module.ts
+++ b/samples/boot/03-use-bootvalue-decorator/app.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 import { BootModule } from '@nestcloud/boot';
 import { ConfigService } from "./config.service";
+import { resolve } from 'path'
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
     ],
     providers: [ConfigService],
 })

--- a/samples/consul-config/01-get-config/app.module.ts
+++ b/samples/consul-config/01-get-config/app.module.ts
@@ -4,10 +4,14 @@ import { ConsulModule } from '@nestcloud/consul';
 import { ConsulConfigModule } from '@nestcloud/consul-config';
 import { NEST_BOOT } from '@nestcloud/common';
 import { ConfigService } from "./config.service";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
         ConsulModule.register({ dependencies: [NEST_BOOT] }),
         ConsulConfigModule.register({ dependencies: [NEST_BOOT] })
     ],

--- a/samples/consul-config/01-get-config/app.module.ts
+++ b/samples/consul-config/01-get-config/app.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulConfigModule } from '@nestcloud/consul-config';
-import { NEST_BOOT } from '@nestcloud/common';
+import { BOOT } from '@nestcloud/common';
 import { ConfigService } from "./config.service";
 import { resolve } from 'path'
 
@@ -12,8 +12,8 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulConfigModule.register({ dependencies: [NEST_BOOT] })
+        ConsulModule.forRootAsync({ inject: [BOOT] }),
+        ConsulConfigModule.forRootAsync({ inject: [BOOT] })
     ],
     providers: [ConfigService],
 })

--- a/samples/consul-config/02-watch/app.module.ts
+++ b/samples/consul-config/02-watch/app.module.ts
@@ -4,10 +4,14 @@ import { ConsulModule } from '@nestcloud/consul';
 import { ConsulConfigModule } from '@nestcloud/consul-config';
 import { NEST_BOOT } from '@nestcloud/common';
 import { ConfigService } from "./config.service";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
         ConsulModule.register({ dependencies: [NEST_BOOT] }),
         ConsulConfigModule.register({ dependencies: [NEST_BOOT] })
     ],

--- a/samples/consul-config/02-watch/app.module.ts
+++ b/samples/consul-config/02-watch/app.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulConfigModule } from '@nestcloud/consul-config';
-import { NEST_BOOT } from '@nestcloud/common';
+import { BOOT } from '@nestcloud/common';
 import { ConfigService } from "./config.service";
 import { resolve } from 'path'
 
@@ -12,8 +12,8 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulConfigModule.register({ dependencies: [NEST_BOOT] })
+        ConsulModule.register({ inject: [BOOT] }),
+        ConsulConfigModule.register({ inject: [BOOT] })
     ],
     providers: [ConfigService],
 })

--- a/samples/consul-config/03-use-configvalue-decorator/app.module.ts
+++ b/samples/consul-config/03-use-configvalue-decorator/app.module.ts
@@ -4,10 +4,14 @@ import { ConsulModule } from '@nestcloud/consul';
 import { ConsulConfigModule } from '@nestcloud/consul-config';
 import { NEST_BOOT } from '@nestcloud/common';
 import { ConfigService } from "./config.service";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
         ConsulModule.register({ dependencies: [NEST_BOOT] }),
         ConsulConfigModule.register({ dependencies: [NEST_BOOT] })
     ],

--- a/samples/consul-config/03-use-configvalue-decorator/app.module.ts
+++ b/samples/consul-config/03-use-configvalue-decorator/app.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulConfigModule } from '@nestcloud/consul-config';
-import { NEST_BOOT } from '@nestcloud/common';
+import { BOOT } from '@nestcloud/common';
 import { ConfigService } from "./config.service";
 import { resolve } from 'path'
 
@@ -12,8 +12,8 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulConfigModule.register({ dependencies: [NEST_BOOT] })
+        ConsulModule.forRootAsync({ inject: [BOOT] }),
+        ConsulConfigModule.forRootAsync({ inject: [BOOT] })
     ],
     providers: [ConfigService],
 })

--- a/samples/consul-loadbalance/01-choose-service-node/app.module.ts
+++ b/samples/consul-loadbalance/01-choose-service-node/app.module.ts
@@ -3,7 +3,7 @@ import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulServiceModule } from '@nestcloud/consul-service';
 import { LoadbalanceModule } from '@nestcloud/consul-loadbalance';
-import { NEST_BOOT } from '@nestcloud/common';
+import { BOOT } from '@nestcloud/common';
 import { LoadbalanceService } from "./loadbalance.service";
 import { resolve } from 'path'
 
@@ -13,9 +13,9 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
-        LoadbalanceModule.register({ dependencies: [NEST_BOOT] })
+        ConsulModule.forRootAsync({ inject: [BOOT] }),
+        ConsulServiceModule.forRootAsync({ inject: [BOOT] }),
+        LoadbalanceModule.forRootAsync({ inject: [BOOT] })
     ],
     providers: [LoadbalanceService],
 })

--- a/samples/consul-loadbalance/01-choose-service-node/app.module.ts
+++ b/samples/consul-loadbalance/01-choose-service-node/app.module.ts
@@ -5,10 +5,14 @@ import { ConsulServiceModule } from '@nestcloud/consul-service';
 import { LoadbalanceModule } from '@nestcloud/consul-loadbalance';
 import { NEST_BOOT } from '@nestcloud/common';
 import { LoadbalanceService } from "./loadbalance.service";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
         ConsulModule.register({ dependencies: [NEST_BOOT] }),
         ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
         LoadbalanceModule.register({ dependencies: [NEST_BOOT] })

--- a/samples/consul-loadbalance/02-custom-lb-rule/app.module.ts
+++ b/samples/consul-loadbalance/02-custom-lb-rule/app.module.ts
@@ -3,7 +3,7 @@ import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulServiceModule } from '@nestcloud/consul-service';
 import { LoadbalanceModule } from '@nestcloud/consul-loadbalance';
-import { NEST_BOOT } from '@nestcloud/common';
+import { BOOT } from '@nestcloud/common';
 import { LoadbalanceService } from "./loadbalance.service";
 import { resolve } from 'path'
 
@@ -13,9 +13,9 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
-        LoadbalanceModule.register({ dependencies: [NEST_BOOT], customRulePath: __dirname })
+        ConsulModule.forRootAsync({ inject: [BOOT] }),
+        ConsulServiceModule.forRootAsync({ inject: [BOOT] }),
+        LoadbalanceModule.forRootAsync({ inject: [BOOT], customRulePath: __dirname })
     ],
     providers: [LoadbalanceService],
 })

--- a/samples/consul-loadbalance/02-custom-lb-rule/app.module.ts
+++ b/samples/consul-loadbalance/02-custom-lb-rule/app.module.ts
@@ -5,10 +5,14 @@ import { ConsulServiceModule } from '@nestcloud/consul-service';
 import { LoadbalanceModule } from '@nestcloud/consul-loadbalance';
 import { NEST_BOOT } from '@nestcloud/common';
 import { LoadbalanceService } from "./loadbalance.service";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
         ConsulModule.register({ dependencies: [NEST_BOOT] }),
         ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
         LoadbalanceModule.register({ dependencies: [NEST_BOOT], customRulePath: __dirname })

--- a/samples/consul-loadbalance/03-use-choose-decorator/app.module.ts
+++ b/samples/consul-loadbalance/03-use-choose-decorator/app.module.ts
@@ -3,7 +3,7 @@ import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulServiceModule } from '@nestcloud/consul-service';
 import { LoadbalanceModule } from '@nestcloud/consul-loadbalance';
-import { NEST_BOOT } from '@nestcloud/common';
+import { BOOT } from '@nestcloud/common';
 import { LoadbalanceService } from "./loadbalance.service";
 import { resolve } from 'path'
 
@@ -13,9 +13,9 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
-        LoadbalanceModule.register({ dependencies: [NEST_BOOT] })
+        ConsulModule.forRootAsync({ inject: [BOOT] }),
+        ConsulServiceModule.forRootAsync({ inject: [BOOT] }),
+        LoadbalanceModule.forRootAsync({ inject: [BOOT] })
     ],
     providers: [LoadbalanceService],
 })

--- a/samples/consul-loadbalance/03-use-choose-decorator/app.module.ts
+++ b/samples/consul-loadbalance/03-use-choose-decorator/app.module.ts
@@ -5,10 +5,14 @@ import { ConsulServiceModule } from '@nestcloud/consul-service';
 import { LoadbalanceModule } from '@nestcloud/consul-loadbalance';
 import { NEST_BOOT } from '@nestcloud/common';
 import { LoadbalanceService } from "./loadbalance.service";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
         ConsulModule.register({ dependencies: [NEST_BOOT] }),
         ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
         LoadbalanceModule.register({ dependencies: [NEST_BOOT] })

--- a/samples/consul-service/01-register-service/app.module.ts
+++ b/samples/consul-service/01-register-service/app.module.ts
@@ -4,10 +4,14 @@ import { ConsulModule } from '@nestcloud/consul';
 import { ConsulServiceModule } from '@nestcloud/consul-service';
 import { NEST_BOOT } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
         ConsulModule.register({ dependencies: [NEST_BOOT] }),
         ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
         TerminusModule.forRootAsync({

--- a/samples/consul-service/01-register-service/app.module.ts
+++ b/samples/consul-service/01-register-service/app.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulServiceModule } from '@nestcloud/consul-service';
-import { NEST_BOOT } from '@nestcloud/common';
+import { BOOT } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { resolve } from 'path'
 
@@ -12,8 +12,8 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
+        ConsulModule.forRootAsync({ inject: [BOOT] }),
+        ConsulServiceModule.forRootAsync({ inject: [BOOT] }),
         TerminusModule.forRootAsync({
             useFactory: () => ({ endpoints: [{ url: '/health', healthIndicators: [] }] }),
         }),

--- a/samples/consul-service/02-discovery-service/app.module.ts
+++ b/samples/consul-service/02-discovery-service/app.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulServiceModule } from '@nestcloud/consul-service';
-import { NEST_BOOT } from '@nestcloud/common';
+import { BOOT } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { DiscoveryService } from "./discovery.service";
 import { resolve } from 'path'
@@ -13,8 +13,8 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
+        ConsulModule.forRootAsync({ inject: [BOOT] }),
+        ConsulServiceModule.forRootAsync({ inject: [BOOT] }),
         TerminusModule.forRootAsync({
             useFactory: () => ({ endpoints: [{ url: '/health', healthIndicators: [] }] }),
         }),

--- a/samples/consul-service/02-discovery-service/app.module.ts
+++ b/samples/consul-service/02-discovery-service/app.module.ts
@@ -5,10 +5,14 @@ import { ConsulServiceModule } from '@nestcloud/consul-service';
 import { NEST_BOOT } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { DiscoveryService } from "./discovery.service";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
         ConsulModule.register({ dependencies: [NEST_BOOT] }),
         ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
         TerminusModule.forRootAsync({

--- a/samples/consul-service/03-health-check/app.module.ts
+++ b/samples/consul-service/03-health-check/app.module.ts
@@ -4,10 +4,14 @@ import { ConsulModule } from '@nestcloud/consul';
 import { ConsulServiceModule } from '@nestcloud/consul-service';
 import { NEST_BOOT } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
         ConsulModule.register({ dependencies: [NEST_BOOT] }),
         ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
         TerminusModule.forRootAsync({

--- a/samples/consul-service/03-health-check/app.module.ts
+++ b/samples/consul-service/03-health-check/app.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulServiceModule } from '@nestcloud/consul-service';
-import { NEST_BOOT } from '@nestcloud/common';
+import { BOOT } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { resolve } from 'path'
 
@@ -12,8 +12,8 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
+        ConsulModule.forRootAsync({ inject: [BOOT] }),
+        ConsulServiceModule.forRootAsync({ inject: [BOOT] }),
         TerminusModule.forRootAsync({
             useFactory: () => ({ endpoints: [{ url: '/health', healthIndicators: [] }] }),
         }),

--- a/samples/consul/01-inject-consul/app.module.ts
+++ b/samples/consul/01-inject-consul/app.module.ts
@@ -1,13 +1,17 @@
 import { Module } from '@nestjs/common';
 import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
-import { NEST_BOOT } from '@nestcloud/common';
+import { BOOT } from '@nestcloud/common';
 import { ConsulService } from "./consul.service";
+import { resolve } from 'path'
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
-        ConsulModule.register({ dependencies: [NEST_BOOT] })
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
+        ConsulModule.forRootAsync({ inject: [BOOT] }),
+
     ],
     providers: [ConsulService],
 })

--- a/samples/consul/02-use-watchkv-decorator/app.module.ts
+++ b/samples/consul/02-use-watchkv-decorator/app.module.ts
@@ -1,13 +1,17 @@
 import { Module } from '@nestjs/common';
 import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
-import { NEST_BOOT } from '@nestcloud/common';
+import { BOOT } from '@nestcloud/common';
 import { ConsulService } from "./consul.service";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
-        ConsulModule.register({ dependencies: [NEST_BOOT] })
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
+        ConsulModule.forRootAsync({ inject: [BOOT] })
     ],
     providers: [ConsulService],
 })

--- a/samples/feign/01-simple-http-call/app.module.ts
+++ b/samples/feign/01-simple-http-call/app.module.ts
@@ -3,12 +3,12 @@ import { BootModule } from '@nestcloud/boot';
 import { FeignModule } from '@nestcloud/feign';
 import { HttpClient } from "./http.client";
 import { TestService } from "./test.service";
-import { NEST_BOOT } from "@nestcloud/common";
+import { BOOT } from "@nestcloud/common";
 
 @Module({
     imports: [
         BootModule.register(__dirname, 'config.yaml'),
-        FeignModule.register({dependencies: [NEST_BOOT]}),
+        FeignModule.register({inject: [BOOT]}),
     ],
     providers: [HttpClient, TestService],
 })

--- a/samples/feign/02-lb-http-call/app.module.ts
+++ b/samples/feign/02-lb-http-call/app.module.ts
@@ -7,10 +7,14 @@ import { NEST_BOOT, NEST_CONSUL_LOADBALANCE } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HttpClient } from "./http.client";
 import { TestService } from "./test.service";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
         ConsulModule.register({ dependencies: [NEST_BOOT] }),
         ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
         FeignModule.register({ dependencies: [NEST_BOOT, NEST_CONSUL_LOADBALANCE] }),

--- a/samples/feign/02-lb-http-call/app.module.ts
+++ b/samples/feign/02-lb-http-call/app.module.ts
@@ -3,7 +3,7 @@ import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulServiceModule } from '@nestcloud/consul-service';
 import { FeignModule } from '@nestcloud/feign';
-import { BOOT, NEST_CONSUL_LOADBALANCE } from '@nestcloud/common';
+import { BOOT, LOADBALANCE } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HttpClient } from "./http.client";
 import { TestService } from "./test.service";
@@ -15,9 +15,9 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ inject: [BOOT] }),
-        ConsulServiceModule.register({ inject: [BOOT] }),
-        FeignModule.register({ inject: [BOOT, NEST_CONSUL_LOADBALANCE] }),
+        ConsulModule.forRootAsync({ inject: [BOOT] }),
+        ConsulServiceModule.forRootAsync({ inject: [BOOT] }),
+        FeignModule.forRootAsync({ inject: [BOOT, LOADBALANCE] }),
         TerminusModule.forRootAsync({
             useFactory: () => ({ endpoints: [{ url: '/health', healthIndicators: [] }] }),
         }),

--- a/samples/feign/02-lb-http-call/app.module.ts
+++ b/samples/feign/02-lb-http-call/app.module.ts
@@ -3,7 +3,7 @@ import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulServiceModule } from '@nestcloud/consul-service';
 import { FeignModule } from '@nestcloud/feign';
-import { NEST_BOOT, NEST_CONSUL_LOADBALANCE } from '@nestcloud/common';
+import { BOOT, NEST_CONSUL_LOADBALANCE } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HttpClient } from "./http.client";
 import { TestService } from "./test.service";
@@ -15,9 +15,9 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
-        FeignModule.register({ dependencies: [NEST_BOOT, NEST_CONSUL_LOADBALANCE] }),
+        ConsulModule.register({ inject: [BOOT] }),
+        ConsulServiceModule.register({ inject: [BOOT] }),
+        FeignModule.register({ inject: [BOOT, NEST_CONSUL_LOADBALANCE] }),
         TerminusModule.forRootAsync({
             useFactory: () => ({ endpoints: [{ url: '/health', healthIndicators: [] }] }),
         }),

--- a/samples/feign/03-brakes/app.module.ts
+++ b/samples/feign/03-brakes/app.module.ts
@@ -3,7 +3,7 @@ import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulServiceModule } from '@nestcloud/consul-service';
 import { FeignModule } from '@nestcloud/feign';
-import { NEST_BOOT, NEST_CONSUL_LOADBALANCE } from '@nestcloud/common';
+import { BOOT, LOADBALANCE } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HttpClient } from "./http.client";
 import { TestService } from "./test.service";
@@ -16,9 +16,9 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
-        FeignModule.register({ dependencies: [NEST_BOOT, NEST_CONSUL_LOADBALANCE] }),
+        ConsulModule.forRootAsync({ inject: [BOOT] }),
+        ConsulServiceModule.forRootAsync({ inject: [BOOT] }),
+        FeignModule.forRootAsync({ inject: [BOOT, LOADBALANCE] }),
         TerminusModule.forRootAsync({
             useFactory: () => ({ endpoints: [{ url: '/health', healthIndicators: [] }] }),
         }),

--- a/samples/feign/03-brakes/app.module.ts
+++ b/samples/feign/03-brakes/app.module.ts
@@ -8,10 +8,14 @@ import { TerminusModule } from '@nestjs/terminus';
 import { HttpClient } from "./http.client";
 import { TestService } from "./test.service";
 import { HealthClient } from "./health.client";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
         ConsulModule.register({ dependencies: [NEST_BOOT] }),
         ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
         FeignModule.register({ dependencies: [NEST_BOOT, NEST_CONSUL_LOADBALANCE] }),

--- a/samples/feign/04-interceptor/app.module.ts
+++ b/samples/feign/04-interceptor/app.module.ts
@@ -7,10 +7,14 @@ import { NEST_BOOT, NEST_CONSUL_LOADBALANCE } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HttpClient } from "./http.client";
 import { TestService } from "./test.service";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
         ConsulModule.register({ dependencies: [NEST_BOOT] }),
         ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
         FeignModule.register({ dependencies: [NEST_BOOT, NEST_CONSUL_LOADBALANCE] }),

--- a/samples/feign/04-interceptor/app.module.ts
+++ b/samples/feign/04-interceptor/app.module.ts
@@ -3,7 +3,7 @@ import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulServiceModule } from '@nestcloud/consul-service';
 import { FeignModule } from '@nestcloud/feign';
-import { NEST_BOOT, NEST_CONSUL_LOADBALANCE } from '@nestcloud/common';
+import { BOOT, LOADBALANCE } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HttpClient } from "./http.client";
 import { TestService } from "./test.service";
@@ -15,9 +15,9 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
-        FeignModule.register({ dependencies: [NEST_BOOT, NEST_CONSUL_LOADBALANCE] }),
+        ConsulModule.forRootAsync({ inject: [BOOT] }),
+        ConsulServiceModule.forRootAsync({ inject: [BOOT] }),
+        FeignModule.forRootAsync({ inject: [BOOT, LOADBALANCE] }),
         TerminusModule.forRootAsync({
             useFactory: () => ({ endpoints: [{ url: '/health', healthIndicators: [] }] }),
         }),

--- a/samples/proxy/01-forward-request/app.module.ts
+++ b/samples/proxy/01-forward-request/app.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulServiceModule } from '@nestcloud/consul-service';
-import { NEST_BOOT } from '@nestcloud/common';
+import { BOOT } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { GatewayModule } from '@nestcloud/gateway';
 import { ApiController } from "./api.controller";
@@ -14,9 +14,9 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
-        GatewayModule.register({ dependencies: [NEST_BOOT] }),
+        ConsulModule.forRootAsync({ inject: [BOOT] }),
+        ConsulServiceModule.forRootAsync({ inject: [BOOT] }),
+        GatewayModule.forRootAsync({ inject: [BOOT] }),
         TerminusModule.forRootAsync({
             useFactory: () => ({ endpoints: [{ url: '/health', healthIndicators: [] }] }),
         }),

--- a/samples/proxy/01-forward-request/app.module.ts
+++ b/samples/proxy/01-forward-request/app.module.ts
@@ -6,10 +6,14 @@ import { NEST_BOOT } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { GatewayModule } from '@nestcloud/gateway';
 import { ApiController } from "./api.controller";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
         ConsulModule.register({ dependencies: [NEST_BOOT] }),
         ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
         GatewayModule.register({ dependencies: [NEST_BOOT] }),

--- a/samples/proxy/02-dynamic-routes/app.module.ts
+++ b/samples/proxy/02-dynamic-routes/app.module.ts
@@ -8,10 +8,14 @@ import { TerminusModule } from '@nestjs/terminus';
 import { GatewayModule } from '@nestcloud/gateway';
 import { ApiController } from "./api.controller";
 import { GatewayService } from "./gateway.service";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
         ConsulModule.register({ dependencies: [NEST_BOOT] }),
         ConsulConfigModule.register({ dependencies: [NEST_BOOT] }),
         ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),

--- a/samples/proxy/02-dynamic-routes/app.module.ts
+++ b/samples/proxy/02-dynamic-routes/app.module.ts
@@ -3,7 +3,7 @@ import { BootModule } from '@nestcloud/boot';
 import { ConsulModule } from '@nestcloud/consul';
 import { ConsulConfigModule } from '@nestcloud/consul-config';
 import { ConsulServiceModule } from '@nestcloud/consul-service';
-import { NEST_BOOT, NEST_CONSUL_CONFIG } from '@nestcloud/common';
+import { BOOT, NEST_CONSUL } from '@nestcloud/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { GatewayModule } from '@nestcloud/gateway';
 import { ApiController } from "./api.controller";
@@ -16,10 +16,10 @@ import { resolve } from 'path'
         BootModule.forRoot({
             filePath: resolve(__dirname, `config.yaml`)
         }),
-        ConsulModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulConfigModule.register({ dependencies: [NEST_BOOT] }),
-        ConsulServiceModule.register({ dependencies: [NEST_BOOT] }),
-        GatewayModule.register({ dependencies: [NEST_CONSUL_CONFIG] }),
+        ConsulModule.forRootAsync({ inject: [BOOT] }),
+        ConsulConfigModule.forRootAsync({ inject: [BOOT] }),
+        ConsulServiceModule.forRootAsync({ inject: [BOOT] }),
+        GatewayModule.forRootAsync({ dependencies: [NEST_CONSUL] }),
         TerminusModule.forRootAsync({
             useFactory: () => ({ endpoints: [{ url: '/health', healthIndicators: [] }] }),
         }),

--- a/samples/validations/01-param-validation/app.module.ts
+++ b/samples/validations/01-param-validation/app.module.ts
@@ -1,10 +1,14 @@
 import { Module } from '@nestjs/common';
 import { BootModule } from '@nestcloud/boot';
 import { ConfigService } from "./config.service";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
     ],
     providers: [ConfigService],
 })

--- a/samples/validations/02-class-validation/app.module.ts
+++ b/samples/validations/02-class-validation/app.module.ts
@@ -1,10 +1,14 @@
 import { Module } from '@nestjs/common';
 import { BootModule } from '@nestcloud/boot';
 import { ConfigService } from "./config.service";
+import { resolve } from 'path'
+
 
 @Module({
     imports: [
-        BootModule.register(__dirname, `config.yaml`),
+        BootModule.forRoot({
+            filePath: resolve(__dirname, `config.yaml`)
+        }),
     ],
     providers: [ConfigService],
 })


### PR DESCRIPTION
@miaowing I updated the sample code within the repository to use the `forRootAsync` method in all Modules and also updated the provider constants being used.

This way people can have less issues when referencing the sample code.