### PR TITLE
Modification of ClientOption to allow using any proto config field of…

### DIFF
--- a/packages/grpc/grpc-client.ts
+++ b/packages/grpc/grpc-client.ts
@@ -46,9 +46,8 @@ export class GrpcClient {
         if (!this.serviceCache.get(methodKey)) {
             if (!this.proxyCache.has(node.id)) {
                 const proxy = new ClientGrpcProxy({
-                    url: `${node.address}:${node.port}`,
-                    package: this.options.package,
-                    protoPath: this.options.protoPath,
+                    ...(this.options),
+                    url: `${node.address}:${node.port}`
                 });
                 this.proxyCache.set(node.id, proxy);
             }

--- a/packages/grpc/interfaces/client-options.interface.ts
+++ b/packages/grpc/interfaces/client-options.interface.ts
@@ -1,6 +1,7 @@
-export interface ClientOptions {
-    service?: string;
-    url?: string;
-    package: string;
-    protoPath: string;
+import { GrpcOptions } from '@nestjs/microservices';
+
+type GrpcOptionsOptions = GrpcOptions['options'];
+
+export interface ClientOptions extends GrpcOptionsOptions {
+  service?: string;
 }


### PR DESCRIPTION
… nestJS

The aim of this PR is to allow the usage of proto loader options, in my case, I need to use multiple proto files and grpc client side, with Service decorator, it is impossible to specify loader options as for example :
    loader: {
      includeDirs: ['dto/proto/'],
    }
