### PR TITLE
fix: tags maybe null and will throw err now

### DIFF
--- a/packages/loadbalance/loadbalance.ts
+++ b/packages/loadbalance/loadbalance.ts
@@ -116,7 +116,7 @@ export class Loadbalance implements ILoadbalance, OnModuleInit {
                 server.state = new ServerState();
             }
             server.state.status = node.status;
-            server.tags = stringToKeyValue(node.tags);
+            if (server.tags) server.tags = stringToKeyValue(node.tags);
             return server;
         });
 


### PR DESCRIPTION
when tags don't set in config.yaml, it throws an error TypeError: Cannot read property 'forEach' of null. because the node.tags are null 